### PR TITLE
Add QUIC's port (40005) to security group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -54,6 +54,14 @@ resource "aws_security_group" "stcv_mgmt_plane" {
     cidr_blocks = var.ingress_cidr_blocks
   }
 
+  # STC portgroup (QUIC)
+  ingress {
+    from_port   = 51204
+    to_port     = 51204
+    protocol    = "udp"
+    cidr_blocks = var.ingress_cidr_blocks
+  }
+
   # SSH
   ingress {
     from_port   = 22
@@ -67,6 +75,14 @@ resource "aws_security_group" "stcv_mgmt_plane" {
     from_port   = 49100
     to_port     = 65535
     protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # STCv to GUI/BLL (QUIC)
+  egress {
+    from_port   = 49100
+    to_port     = 65535
+    protocol    = "udp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 

--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,14 @@ resource "aws_security_group" "stcv_mgmt_plane" {
     cidr_blocks = var.ingress_cidr_blocks
   }
 
+  # STC chassis (QUIC)
+  ingress {
+    from_port   = 40005
+    to_port     = 40005
+    protocol    = "udp"
+    cidr_blocks = var.ingress_cidr_blocks
+  }
+
   # STC portgroup
   ingress {
     from_port   = 51204


### PR DESCRIPTION
Add QUIC's port (40005) to AWS security group so BLL can connect to it from the outside world.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Spirent-Terraform-Modules/terraform-aws-stcv/12)
<!-- Reviewable:end -->
